### PR TITLE
link session videos on youtube

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
                     <ul>
                       <li>🎓 Proceedings of Academic Track are <a href="https://zenodo.org/record/7004791">published on Zenodo</a>.</li>
                       <li>🖼️ Posters are published <a href="/posters/">on the website</a>.</li>
-                      <li>🎥 The recordings of the talks will be made available after the conference.</li>
+                      <li>🎥 Session videos are appearing <a href="https://www.youtube.com/c/StateoftheMap/videos">on our channel</a> (editing in progress)</li>
                       <li>Follow <a href="https://twitter.com/sotm">@SotM</a> on Twitter and use the hashtag <a href="https://twitter.com/hashtag/sotm2022">#sotm2022</a>.</li>
                       <li>Connect with others in our <a href="https://t.me/sotm2018">telegram group chat</a> and share your State of the Map experience.</li>
                       <li>Read Ilya's and Gregory's <a href="https://t.me/sotm2022_live/3">State of the Map 2022 Live</a> blog which they wrote during and around the confrence.</li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
                     <ul>
                       <li>🎓 Proceedings of Academic Track are <a href="https://zenodo.org/record/7004791">published on Zenodo</a>.</li>
                       <li>🖼️ Posters are published <a href="/posters/">on the website</a>.</li>
-                      <li>🎥 Session videos are appearing <a href="https://www.youtube.com/c/StateoftheMap/videos">on our channel</a> (editing in progress)</li>
+                      <li>🎥 Session videos are appearing on <a href="https://media.ccc.de/c/sotm2022">media.ccc.de</a> as well as on our <a href="https://www.youtube.com/watch?v=t6PmaShD0f8&list=PLQNy8KsDknCo4Hpk5_trylRC8FD2ge9ns">youtube channel</a> (editing in progress)</li>
                       <li>Follow <a href="https://twitter.com/sotm">@SotM</a> on Twitter and use the hashtag <a href="https://twitter.com/hashtag/sotm2022">#sotm2022</a>.</li>
                       <li>Connect with others in our <a href="https://t.me/sotm2018">telegram group chat</a> and share your State of the Map experience.</li>
                       <li>Read Ilya's and Gregory's <a href="https://t.me/sotm2022_live/3">State of the Map 2022 Live</a> blog which they wrote during and around the confrence.</li>


### PR DESCRIPTION
Link the session videos (so far) on the youtube channel.

...with an "editing in progress" note.
(Am I correct to say they're not all there yet? Obviously this note should ideally be removed when all the videos are on there) 